### PR TITLE
Small Fix for Mojang Shenanigan, Update GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 **/build/
 !src/**/build/
 
-# Screws up the MC dev plugin for IntelliJ..
-# src/btw/**
+# (Screws up the MC dev plugin for Older IntelliJ Versions)
+src/btw/**
 
 # Ignore local Minecraft folder
 .minecraft

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ plugins {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
+downloadAssets.enabled = false
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version


### PR DESCRIPTION
Added downloadAssets.enabled = false to Build.Gradle
Uncommented GitIgnore to automatically ignore BTW Source.